### PR TITLE
BUG don't use `-march=native` on linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "libsharp" %}
 {% set version = "1.0.0" %}
 
-{% set build = 1003 %}
+{% set build = 1004 %}
 
 {% set mpi = mpi or 'nompi' %}
 
@@ -24,7 +24,7 @@ source:
   url: https://github.com/Libsharp/libsharp/archive/v{{ version }}.tar.gz
   sha256: ca7cc7790c98bd5637a8a3d84460c02a54e5132b3184e713e596cd70c3cd59c0
   patches:
-    - configure.ac.patch  # [osx]
+    - configure.ac.patch
     - setup.py.patch
 
 build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@conda-forge-admin rerender